### PR TITLE
Bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ For each `MeshesMessage.Chunk`, the following fields are contained:
 * chunk_id: the index of this chunk among all the chunks splited from the original meshes file
 * chunk: the content, a part of the original meshes file
 
-### PointCloudMessage
+### DeformableMeshesMessage
 
-The message contains a meshes **created from a point cloud**. Thus, when it is sent, it will be wrapped into a [`MeshesMessage`](#meshesmessage) object. 
+The message contains a meshes **created from a point cloud or SDF values**. Thus, when it is sent, it will be wrapped into a [`MeshesMessage`](#meshesmessage) object. 
 
-此消息包含了一个从点云重构的meshes对象。因此，当它被sent的时候，会被包装成一个[`MeshesMessage`](#meshesmessage)对象。
+此消息包含了一个从点云或者SDF值重构的meshes对象。因此，当它被sent的时候，会被包装成一个[`MeshesMessage`](#meshesmessage)对象。
 
-A `PointCloudMessage` contains the following fields: 
+A `DeformableMeshesMessage` contains the following fields: 
 
 * `obj_name`: the name of the meshes created from this point cloud
 * `frame_idx`: frame index of the meshes to appear
@@ -58,7 +58,7 @@ A `PointCloudMessage` contains the following fields:
 
 _You may note that for the [`MeshesMessage`](#meshesmessage), no `frame_idx` field is specified. This is because as for the objected created from meshes files, it is always regarded as the rigid-bodies, whose shape will not changed. Thus, to save the communication brandwidth, we split the **initialization** or **pose updating** into two message types. The message for updating a rigid-body object's meshes is called [`UpdateRigidBodyPoseMessage`](#updaterigidbodyposemessage)_
 
-_你可能会注意到，[`MeshesMessage`](#meshesmessage)中没有`frame_idx`成员。这是因为只有从点云重构的meshes才会被视作可形变（Deformable）物体，`*.DAE`或者`*.STL`等等格式描述的meshes则会被视作刚体。因此，对于每个frame来说，一个刚体的[`MeshesMessage`](#meshesmessage)对象之间差别只有pose不同，meshes的内容是完全一致的。为了节省带宽，我们在设计时，区分了刚体的**创建**和**姿态更新**，后者使用下面的[`UpdateRigidBodyPoseMessage`](#updaterigidbodyposemessage)处理。_
+_你可能会注意到，[`MeshesMessage`](#meshesmessage)中没有`frame_idx`成员。这是因为只有从点云或SDF值重构的meshes才会被视作可形变（Deformable）物体，`*.DAE`或者`*.STL`等等格式描述的meshes则会被视作刚体。因此，对于每个frame来说，一个刚体的[`MeshesMessage`](#meshesmessage)对象之间差别只有pose不同，meshes的内容是完全一致的。为了节省带宽，我们在设计时，区分了刚体的**创建**和**姿态更新**，后者使用下面的[`UpdateRigidBodyPoseMessage`](#updaterigidbodyposemessage)处理。_
 
 _For more details on keyframe animation, you may refer to the [Animation](#animation) section._
 
@@ -115,9 +115,9 @@ Keyframe animation is adopted. One message is sent to update one object in one c
 
 ### Animation for deformable objects
 
-As for deformable objects, for each frame, the meshes that describing the object surface can be different. Thus, the meshes (vertices and faces) shall be sent for every keyframe. Hence, the intialization and the pose updating are exactly the same, both using the [`PointCloudMessage`](#pointcloudmessage) with the only difference is the frame index. To initialize a deformable object, the frame index in a [`PointCloudMessage`](#pointcloudmessage) is **0**. As for the pose updating scenario, the frame index is the index of the keyframe. 
+As for deformable objects, for each frame, the meshes that describing the object surface can be different. Thus, the meshes (vertices and faces) shall be sent for every keyframe. Hence, the intialization and the pose updating are exactly the same, both using the [`DeformableMeshesMessage`](#deformablemeshesmessage) with the only difference is the frame index. To initialize a deformable object, the frame index in a [`DeformableMeshesMessage`](#deformablemeshesmessage) is **0**. As for the pose updating scenario, the frame index is the index of the keyframe. 
 
-对于可形变物体，每一帧它们的meshes描述（顶点、面等）可能都会不一样。因此，每一帧的消息中都必定包含meshes信息。所以，对于可形变物体而言，最初物体的创建和关键帧姿态的更新几乎没有区别，都使用了[`PointCloudMessage`](#pointcloudmessage)；而唯一的区别只是frame index。对于创建物体来说，frame index应当设置为**0**，而姿态更新的frame index则是关键帧的序号。
+对于可形变物体，每一帧它们的meshes描述（顶点、面等）可能都会不一样。因此，每一帧的消息中都必定包含meshes信息。所以，对于可形变物体而言，最初物体的创建和关键帧姿态的更新几乎没有区别，都使用了[`DeformableMeshesMessage`](#deformablemeshesmessage)；而唯一的区别只是frame index。对于创建物体来说，frame index应当设置为**0**，而姿态更新的frame index则是关键帧的序号。
 
 ### Animation for rigid-body objects
 
@@ -153,7 +153,7 @@ def message_handler(message: BaseMessage) -> None:
     if type(message) == MeshesMessage: 
         # add the meshes to the renderer
         pass
-    elif type(messasge) == PointCloudMessage:
+    elif type(messasge) == DeformableMeshesMessage:
         # add or update the meshes re-constructed from the pointcloud
         pass
     ...

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 from .message import (
     BaseMessage,
-    PointCloudMessage,
+    DeformableMeshesMessage,
     MeshesMessage,
     AddRigidBodyPrimitiveMessage,
     UpdateRigidBodyPoseMessage,
@@ -13,7 +13,7 @@ from .server_util import (
 
 __all__ = [
     'BaseMessage',
-    'PointCloudMessage',
+    'DeformableMeshesMessage',
     'MeshesMessage',
     'AddRigidBodyPrimitiveMessage',
     'UpdateRigidBodyPoseMessage',

--- a/message.py
+++ b/message.py
@@ -3,7 +3,7 @@ from abc import ABC
 import pickle
 import socket
 import threading
-from typing import Any, ByteString, List, Tuple, Union
+from typing import Any, ByteString, Dict, List, Tuple, Union
 import warnings
 
 import numpy as np
@@ -190,14 +190,14 @@ class MeshesMessage(BaseMessage):
         return bstr
     
 class AddRigidBodyPrimitiveMessage(BaseMessage):
+    """
+    Params
+    ------
+    primitive_name: the identifier of the primitive
+    typename_in_bpy: the corresponding typename in the BPY
+    params: the keyword parameters to create the primitive in the BPY
+    """
     def __init__(self, primitive_name:str, typename_in_bpy: str, **params: Any) -> None:
-        """
-        Params
-        ------
-        primitive_name: the identifier of the primitive
-        typename_in_bpy: the corresponding typename in the BPY
-        params: the keyword parameters to create the primitive in the BPY
-        """
         super().__init__()
         self.primitive_name = primitive_name
         self.primitive_type = typename_in_bpy
@@ -208,60 +208,114 @@ class AddRigidBodyPrimitiveMessage(BaseMessage):
         """
         return eval(self.primitive_type)(**self.params)
 
-class PointCloudMessage(BaseMessage):
-    _prev_frame_idx = None
+class DeformableMeshesMessage(BaseMessage):
+    """
+    It is DEPRECATED to directly initialize a 
+    DeformableMeshesMessage. An advisable way is to rely on the
+    DeformableMeshesMessage.Factory class to generate the meshes
+    from either pointcloud or sdf values.
+
+    Params
+    ------
+    name: the object name
+    frame_idx: the frame index at which the deformation is in effect
+    particles: a (N, 3) array storing meshes vertices
+    faces: a (M, 3) array, where each row is the vertex indices of one
+        triangle face in this meshes
+    """
+    _name_2_frame_idx: Dict[str, int] = {}
     _frame_lock = threading.RLock()
-    def __init__(self, particles: np.ndarray, name: str, frame_idx: int) -> None:
-        """ Set a point cloud
+
+    def __init__(self, name: str, frame_idx: int, particles: np.ndarray, faces: np.ndarray) -> None:
+        super().__init__()
+        self.obj_name = name
+        self.frame_idx = frame_idx
+        self.prev_frame_idx = None
+        """ the frame idx of the previous message
+        of the same object
+        """
+        self._update_frame_index()
+        self.particles = particles
+        self.faces = faces
+
+
+    def _update_frame_index(self) -> None:
+        """ Assign value to the `self.prev_frame_idx`
+
+        This is thread-safe. 
+        """
+        DeformableMeshesMessage._frame_lock.acquire()
+        try:
+            self.prev_frame_idx = DeformableMeshesMessage._name_2_frame_idx.get(self.obj_name, None)
+            DeformableMeshesMessage._name_2_frame_idx[self.obj_name] = self.frame_idx
+        finally:
+            DeformableMeshesMessage._frame_lock.release()
+
+    def send(self, retry_times=0):
+        # NOTE: the message will be wrapped in a MeshesMessage to send. You
+        # may refer to the README regarding why it is designed in this way
+        wrap_msg = MeshesMessage(f"MPM::MESHES::{self.obj_name}::{self.frame_idx}", pickle.dumps(self), None)
+        return wrap_msg.send(retry_times)
+
+    class Factory:
+        """ Factory of DeformableMeshesMessage, used to re-construct the
+        meshes from either pointcloud or signed distance function
 
         Params
         ------
-        particles: the surface particle of the point cloud
-        name: the name of the object simulated by this point cloud
-        frame_idx: the frame index
+        name: the object's name
+        frame_idx: the 
+        sdf: the SDF values
+        pcd: the point clouds
+
+        NOTE: either `pcd` or `sdf`, not both, not neither
         """
-        super().__init__()
-        self.obj_name  = name
-        self.frame_idx = frame_idx
-        self.prev_frame_idx = None
-        self.update_frame_index()
-        # build meshes from the particles
-        meshes = self.face_reconstruction(particles)
-        np_particles = np.asarray(meshes.vertices)
-        np_faces = np.asarray(meshes.triangles)
-        self.particles = [np_particles[i, :] for i in range(np_particles.shape[0])]
-        self.faces = [np_faces[i, :] for i in range(np_faces.shape[0])]
+        def __init__(self, name: str, frame_idx: int, sdf = None, pcd = None) -> None:
+            self.name = name
+            self.frame_idx = frame_idx
+            self.sdf = sdf
+            self.pcd = pcd
+            if sdf != None and pcd != None:
+                raise ValueError("PCD and SDF cannot be set together")
+            if sdf == pcd == None:
+                raise ValueError("PCD and SDF cannot both be NONE")
+        
+        @classmethod
+        def _face_reconstruction(cls, pcd: np.ndarray) -> o3d.geometry.TriangleMesh:
+            # step 1: build a o3d pcd
+            vertices = o3d.utility.Vector3dVector(pcd.reshape((-1, 3)))
+            point_cloud = o3d.geometry.PointCloud(vertices)
+            point_cloud.estimate_normals()
+            # step 2: average the distance to get the radius
+            distances = point_cloud.compute_nearest_neighbor_distance()
+            radius = np.mean(distances) * 1.5
+            meshes = o3d.geometry.TriangleMesh.create_from_point_cloud_ball_pivoting(
+                point_cloud, 
+                o3d.utility.DoubleVector([radius, radius * 2])
+            )
+            return meshes
+        
+        @property
+        def message(self) -> "DeformableMeshesMessage":
+            """ Generate the meshes and wrap it into a DeformableMeshesMessage
 
+            If `pcd` is set, the meshes will be re-constructed using ball
+            pivoting; otherwise, when the `sdf` is set, Open3D's RGBD
+            integration will be used to re-construct the meshes
 
-    def update_frame_index(self) -> None:
-        """ generate a global unique id for this message
-        """
-        PointCloudMessage._frame_lock.acquire()
-        try:
-            self.prev_frame_idx = PointCloudMessage._prev_frame_idx
-            PointCloudMessage._prev_frame_idx = self.frame_idx
-        finally:
-            PointCloudMessage._frame_lock.release()
-    
-    @staticmethod
-    def face_reconstruction(pcd: np.ndarray) -> o3d.geometry.TriangleMesh:
-        # step 1: build a o3d pcd
-        vertices = o3d.utility.Vector3dVector(pcd.reshape((-1, 3)))
-        point_cloud = o3d.geometry.PointCloud(vertices)
-        point_cloud.estimate_normals()
-        # step 2: average the distance to get the radius
-        distances = point_cloud.compute_nearest_neighbor_distance()
-        radius = np.mean(distances) * 1.5
-        meshes = o3d.geometry.TriangleMesh.create_from_point_cloud_ball_pivoting(
-            point_cloud, 
-            o3d.utility.DoubleVector([radius, radius * 2])
-        )
-        return meshes
-
-
-    def send(self, retry_times=0):
-        wrap_msg = MeshesMessage(f"MPM::MESHES::{self.obj_name}::{self.frame_idx}", pickle.dumps(self), None)
-        return wrap_msg.send(retry_times)
+            Return
+            ------
+            The generated DeformableMeshesMessage
+            """
+            if self.pcd != None:
+                o3d_mesh = DeformableMeshesMessage.Factory._face_reconstruction(self.pcd)
+            else:
+                pass
+            np_particles = np.asarray(o3d_mesh.vertices)
+            np_faces = np.asarray(o3d_mesh.triangles)
+            particles = [np_particles[i, :] for i in range(np_particles.shape[0])]
+            faces = [np_faces[i, :] for i in range(np_faces.shape[0])]
+            return DeformableMeshesMessage(self.name, self.frame_idx, particles, faces)
 
 class UpdateRigidBodyPoseMessage(BaseMessage):
     """
@@ -280,6 +334,17 @@ class UpdateRigidBodyPoseMessage(BaseMessage):
         self.frame_idx = frame_idx
 
 class FinishAnimationMessage(BaseMessage):
+    """The message marks the end of animation
+
+    The message will cease the renderer server, so no
+    more message can be sent after this message.
+
+    Params
+    ------
+    exp_name: the experiment name, which will be used
+        by the renderer as the file saving name
+    end_frame_idx: the end frame index of the animation
+    """
     def __init__(self, exp_name: str, end_frame_idx: int) -> None:
         super().__init__()
         self.end_frame_idx = end_frame_idx

--- a/message.py
+++ b/message.py
@@ -275,9 +275,9 @@ class DeformableMeshesMessage(BaseMessage):
             self.frame_idx = frame_idx
             self.sdf = sdf
             self.pcd = pcd
-            if sdf != None and pcd != None:
+            if (sdf is not None) and (pcd is not None):
                 raise ValueError("PCD and SDF cannot be set together")
-            if sdf == pcd == None:
+            if (sdf is None) and (pcd is None):
                 raise ValueError("PCD and SDF cannot both be NONE")
         
         @classmethod
@@ -307,7 +307,7 @@ class DeformableMeshesMessage(BaseMessage):
             ------
             The generated DeformableMeshesMessage
             """
-            if self.pcd != None:
+            if self.pcd is not None:
                 o3d_mesh = DeformableMeshesMessage.Factory._face_reconstruction(self.pcd)
             else:
                 pass

--- a/message.py
+++ b/message.py
@@ -211,9 +211,9 @@ class AddRigidBodyPrimitiveMessage(BaseMessage):
 class DeformableMeshesMessage(BaseMessage):
     """
     It is DEPRECATED to directly initialize a 
-    DeformableMeshesMessage. An advisable way is to rely on the
-    DeformableMeshesMessage.Factory class to generate the meshes
-    from either pointcloud or sdf values.
+    DeformableMeshesMessage. An advisable way is to rely on
+    the DeformableMeshesMessage.Factory class to generate
+    the meshes from either pointcloud or sdf values.
 
     Params
     ------

--- a/server_util.py
+++ b/server_util.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import open3d as o3d
 
-from .message import BaseMessage, ResponseMessage, MeshesMessage, PointCloudMessage
+from .message import BaseMessage, ResponseMessage, MeshesMessage, DeformableMeshesMessage
 
 class MeshChunksHandler:
     """ A middleware to merge chunks into its MeshesMessage
@@ -42,7 +42,7 @@ class MeshChunksHandler:
                 del self.mesh_name_2_msg[name]
                 if name.startswith("MPM::MESHES::"):
                     # a open3d re-constructed meshes from point cloud
-                    pcdMessage: PointCloudMessage = pickle.loads(meshmsg.mesh_file)
+                    pcdMessage: DeformableMeshesMessage = pickle.loads(meshmsg.mesh_file)
                     self.handler(pcdMessage)
                 else:
                     # a nomal meshes


### PR DESCRIPTION
# Fix some bugs
1. Fix the wrong `prev_frame_idx` bug
2. Adjust the documents
3. Fix the naming of the pointcloud issue
4. Fix the `== None` bug

## Patch description
### `README.md`

Adjust the doc and change the class names according to the modification of the source codes

### `__init__.py`

Adjust the classes for point cloud deformation

### `message.py`

Add a factory method to create the point cloud message, to cater for the SDF surface re-construction

Fix the `prev_frame_idx` bug associated with the point clouds.

* Previously, the `prev_frame_idx` is set globally. Should there be multiple point clouds, for example, two, namely A and B, the `prev_frame_idx` would be messed up. 
* If cloud A has set keyframe at frame No. 0 and No. 9, while cloud B has set keyframe at frame 0. If the cloud B is going to have a new keyframe at No. 10, its `prev_frame_idx` should be 0. But the original logic give 9, as the `prev_frame_idx` is maintained globally. 
* Now, for each cloud (distinguished by their names), a separated `prev_frame_idx` will be tracked. 

### `server_utils.py` 

Class renaming

## Test

Functional test (the same one as previous) has been passed. 

